### PR TITLE
feature: record unparsed lines instead of skipping them

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    atco (1.0.2)
+    atco (1.0.3)
 
 GEM
   remote: https://rubygems.org/

--- a/docs/links.md
+++ b/docs/links.md
@@ -1,5 +1,6 @@
-* https://ckan.publishing.service.gov.uk/dataset/ulsterbus-and-goldline-timetable-data-from-28-june-31-august-2016
-* https://ckan.publishing.service.gov.uk/dataset/ulsterbus-and-goldline-timetable-data-from-28-june-31-august-2016/resource/6fba35d3-b59c-4eaa-925f-e3dbaa1ea168
-* https://ckan.publishing.service.gov.uk/dataset/ulsterbus-and-goldline-timetable-data-from-28-june-31-august-2016/resource/7b195748-c3f9-4970-b0fb-90a194f7e3b3
-* https://ckan.publishing.service.gov.uk/dataset/ulsterbus-and-goldline-timetable-data-from-28-june-31-august-2016/resource/291cbb54-7bb3-4df7-8599-0c8f49a20be6
+* https://admin.opendatani.gov.uk/dataset/ulsterbus-and-goldline-timetable-data-from-08-11-2023
+  * https://ckan.publishing.service.gov.uk/dataset/ulsterbus-and-goldline-timetable-data-from-28-june-31-august-2016
+  * https://ckan.publishing.service.gov.uk/dataset/ulsterbus-and-goldline-timetable-data-from-28-june-31-august-2016/resource/6fba35d3-b59c-4eaa-925f-e3dbaa1ea168
+  * https://ckan.publishing.service.gov.uk/dataset/ulsterbus-and-goldline-timetable-data-from-28-june-31-august-2016/resource/7b195748-c3f9-4970-b0fb-90a194f7e3b3
+  * https://ckan.publishing.service.gov.uk/dataset/ulsterbus-and-goldline-timetable-data-from-28-june-31-august-2016/resource/291cbb54-7bb3-4df7-8599-0c8f49a20be6
 * https://www.raildeliverygroup.com/files/Publications/services/rsp/RSPS5046_timetable_information_data_feed_interface_specification.pdf

--- a/lib/atco.rb
+++ b/lib/atco.rb
@@ -37,7 +37,7 @@ module Atco # rubocop:disable Metrics/ModuleLength
       header = nil
       unparsed = []
 
-      data.each do |line| # rubocop:disable Metrics/BlockLength
+      data.each_with_index do |line, line_number| # rubocop:disable Metrics/BlockLength
         if line == data.first
           header = parse_header(line)
           next
@@ -70,7 +70,7 @@ module Atco # rubocop:disable Metrics/ModuleLength
           end
           objects << object
         rescue UnidentifiedRecordError
-          unparsed << line
+          unparsed << {line: line, line_number: line_number}
           next
         end
       end

--- a/lib/atco.rb
+++ b/lib/atco.rb
@@ -32,6 +32,7 @@ module Atco # rubocop:disable Metrics/ModuleLength
       locations = []
       journeys = {}
       header = nil
+      unparsed = []
 
       data.each do |line|
         if line == data.first
@@ -40,7 +41,10 @@ module Atco # rubocop:disable Metrics/ModuleLength
         end
         METHODS.each do |method, identifier|
           object = send("parse_#{method}", line)
-          next unless object[:record_identity] && object[:record_identity] == identifier
+          unless object[:record_identity] && object[:record_identity] == identifier
+            unparsed << line
+            next
+          end
 
           current_journey = object if object[:record_identity] && object[:record_identity] == METHODS[:journey_header]
           if object[:record_identity] && (object[:record_identity] == METHODS[:location] || object[:record_identity] == METHODS[:additional_location_info]) # rubocop:disable Layout/LineLength
@@ -61,7 +65,7 @@ module Atco # rubocop:disable Metrics/ModuleLength
           objects << object
         end
       end
-      { header: header, locations: locations, journeys: journeys }
+      { header: header, locations: locations, journeys: journeys, unparsed: unparsed }
     end
 
     def parse_header(string)

--- a/lib/atco/version.rb
+++ b/lib/atco/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Atco
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/spec/atco_spec.rb
+++ b/spec/atco_spec.rb
@@ -194,5 +194,24 @@ RSpec.describe Atco do # rubocop:disable Metrics/BlockLength
       json = JSON.parse(data)
       expect(json).to be_a(Hash)
     end
+
+    it "should return 17 unparsed lines" do
+      expect(@atco[:unparsed].size).to eq(17)
+    end
+
+    it "should not parse GS records" do
+      expect(@atco[:unparsed][0]).to eq({
+        line: "GS00001433 N                    Belfast Metro Ops                                 7000\n",
+        line_number: 3
+      })
+    end
+
+    it "should not parse GR records" do
+      expect(@atco[:unparsed][1]).to eq({
+        line: "GR00001433Donegall Square East                                                                                7000\n",
+        line_number: 4
+      })
+    end
+
   end
 end


### PR DESCRIPTION
* Improved performance 🔥 by extracting the `record identifier` before attempting to call a `parse` method on a given line
* Raises an `UnidentifiedRecordError` if an unidentified record is found
* Enables keeping track of `unparsed` lines and returns them in the resultant data hash as `result[:unparsed]`